### PR TITLE
Changed background color for tab panel

### DIFF
--- a/VSThemeProject/Nordic.vstheme
+++ b/VSThemeProject/Nordic.vstheme
@@ -6668,7 +6668,7 @@
         <Background Type="CT_RAW" Source="FF2E3440" />
       </Color>
       <Color Name="FileTabActiveGroupBackground">
-        <Background Type="CT_RAW" Source="FF27272A" />
+        <Background Type="CT_RAW" Source="FF2E3440" />
       </Color>
       <Color Name="ToolWindowValidationErrorBorder">
         <Background Type="CT_RAW" Source="FFE46364" />


### PR DESCRIPTION
Visual studio has a new vertical tabs feature:

<img height="400" src="https://user-images.githubusercontent.com/27204033/169762803-81b45e4a-368c-4d38-a1c9-bb3f4c2ca489.png"/>

I've changed the default dark mode color for the evrtical tab panel to a nord color. The .vsix file implementing the new change can be found [here](https://github.com/h45h74x/nordic/releases/tag/v1.3.9). Feel free to suggest changes!

<table>
    <tr>
        <th>
            Before
        </th>
        <th>
            After
        </th>
    </tr>
    <tr>
        <td>
            <img height="400px" src="https://user-images.githubusercontent.com/27204033/169761619-94f752e7-bfd0-4b61-b28c-80c623076c9e.png" />
        </td>
        <td>
            <img height="400px" src="https://user-images.githubusercontent.com/27204033/169761605-14783cdf-3d4f-406e-989e-b9c26d6cf4c4.png" />
        </td>
    </tr>
</table>